### PR TITLE
fix/device-username

### DIFF
--- a/docker/johann/main/templates/main/add_devices_single.html
+++ b/docker/johann/main/templates/main/add_devices_single.html
@@ -28,7 +28,7 @@
                         <p>Try it out with the always-on <a href="https://devnetsandbox.cisco.com/" target="_blank">DevNet sandbox</a>:</p>
                         <ul>
                             <li>Address: sandbox-iosxe-latest-1.cisco.com</li>
-                            <li>Username: developer</li>
+                            <li>Username: admin</li>
                             <li>Password: C1sco12345</li>
                         </ul>
                     </div>

--- a/docker/johann/main/templates/main/tools_raw_json.html
+++ b/docker/johann/main/templates/main/tools_raw_json.html
@@ -30,7 +30,7 @@
                         <p>Try it out with the always-on <a href="https://devnetsandbox.cisco.com/" target="_blank">DevNet sandbox</a>:</p>
                         <ul>
                             <li>Address: sandbox-iosxe-latest-1.cisco.com</li>
-                            <li>Username: developer</li>
+                            <li>Username: admin</li>
                             <li>Password: C1sco12345</li>
                         </ul>
                     </div>


### PR DESCRIPTION
Device username has been updated to `admin` instead of `developer` with the same password. Check [IOSXE sandbox login failed](https://community.cisco.com/t5/devnet-sandbox/iosxe-sandbox-login-failed/td-p/4796838)

Hi, @flopach 

I have been learning DevNet with Django to create some ideas, and found your project is a great starting point to learn many things. I hope this (#11) and the other separate pull requests (#7, #8, #9, #10) are considered an improvement for your awesome project.